### PR TITLE
Add requested math, mechanics, turbulence terms and new humanities/hydrodynamics files

### DIFF
--- a/chinese-humanities.md
+++ b/chinese-humanities.md
@@ -1,0 +1,12 @@
+<!--
+title: Chinese Humanities
+tags: [china, humanities, history]
+-->
+
+## Chinese Humanities
+
+- Anyang
+- Erlitou
+- Haojing
+- Luoyang
+- Xianyang

--- a/continuum-mechanics.md
+++ b/continuum-mechanics.md
@@ -16,12 +16,14 @@ tags: [mechanics, materials]
 ### Boundary Geometry
 
 - Unit outward normal vector `n`: A unit-length vector perpendicular to the boundary surface pointing outward from the domain; used to define tractions `t = σ · n`, impose Neumann/flux conditions, and orient surface integrals in divergence theorem applications.
+- Affine BC: An affine boundary condition where prescribed data vary as a linear function plus constant offset (e.g., displacement `u(x) = A x + b` on a boundary segment).
 
 ### Elastic Behavior
 
 - Linear elasticity: Regime where stress is proportional to strain and deformations are fully recoverable after unloading.
 - Hookean material: Ideal linear elastic solid obeying Hooke's law (`sigma = E * epsilon`) within its elastic limit.
 - Non-Hookean material: Exhibits nonlinear stress-strain response such as plasticity, hyperelasticity, or viscoelasticity; tangent or secant moduli depend on load level and history.
+- Neo-Hookean Model: A hyperelastic constitutive model for large strains where strain energy depends on invariants of deformation (often `W = C1 (I1 - 3)` for incompressible response, with volumetric terms for compressible solids).
 
 ### Energy Concepts
 

--- a/fluid-mechanics-environmental-hydrodynamics.md
+++ b/fluid-mechanics-environmental-hydrodynamics.md
@@ -1,0 +1,9 @@
+<!--
+title: Fluid Mechanics and Environmental Hydrodynamics
+tags: [fluid-dynamics, hydrodynamics, environment]
+-->
+
+## Fluid Mechanics and Environmental Hydrodynamics
+
+- Stage
+- Backwater Zone

--- a/mathematics.md
+++ b/mathematics.md
@@ -218,6 +218,15 @@ Brief notes on mathematical concepts, definitions, and problem-solving.
 - Family of second-order, unconditionally stable time integrators that add controllable high-frequency damping for ODEs/structural dynamics.
 - Parameters via spectral radius at infinity `ρ∞ ∈ [0,1]` (0 = max damping, 1 = no extra damping):
   `α_m = (2 ρ∞ - 1)/(ρ∞ + 1)`, `α_f = ρ∞/(ρ∞ + 1)`, `γ = 1/2 + α_f - α_m`, `β = (1/4) (1 + α_f - α_m)^2`.
+
+### Affine Space
+- A geometric set that looks like a vector space with the origin forgotten; points can be subtracted to get vectors, and a point plus a vector gives another point.
+
+### Bethe Lattice
+- An infinite, cycle-free regular graph (each node has fixed coordination number) used in statistical mechanics as a tree-like mean-field model.
+
+### Bifurcation (PDE theory)
+- A parameter-driven qualitative change in the solution set of a PDE, such as symmetry breaking, branch creation, or stability exchange at critical values.
 - Use: Choose `ρ∞ ≈ 0.5–0.8` to damp spurious high-frequency response while keeping low-frequency accuracy.
 
 ### Lp Norms (ℓ2, ℓ∞)

--- a/turbulence.md
+++ b/turbulence.md
@@ -38,3 +38,12 @@ Notes on turbulent flow scales and modeling concepts.
 
 ### Chaotic Statistical Predictability
 - Chaotic systems (turbulence, Lorenz models) lose pointwise predictability quickly, yet their statistical quantities—means, spectra, Reynolds stresses—vary slowly, enabling useful forecasts and closure modeling even when trajectories diverge exponentially.
+
+### Near Wall Model
+- A turbulence-closure treatment for the viscous sublayer and buffer region near solid boundaries, typically using wall functions or low-Re corrections to recover realistic shear stress and velocity profiles.
+
+### RANS (Reynolds Averaged navier Stokes)
+- Reynolds-averaged Navier–Stokes equations govern mean-flow evolution after decomposing fluctuations, requiring turbulence models (e.g., `k-ε`, `k-ω`, Reynolds-stress models) to close the Reynolds-stress terms.
+
+### Entropic Resistance
+- Effective flow resistance associated with entropy production and geometric confinement, where constrictions or microstructure reduce accessible configurations and increase dissipation for transport.


### PR DESCRIPTION
### Motivation
- Add a set of disciplinary terms requested for mathematics, continuum mechanics, and turbulence notes so they are available in the knowledge base. 
- Create two new topic files to host short lists for Chinese humanities and for fluid mechanics / environmental hydrodynamics concepts.

### Description
- Updated `mathematics.md` to add `Affine Space`, `Bethe Lattice`, and `Bifurcation (PDE theory)` as short definition entries. 
- Updated `continuum-mechanics.md` to add entries for `Affine BC` and the `Neo-Hookean Model`. 
- Updated `turbulence.md` to add `Near Wall Model`, `RANS (Reynolds Averaged navier Stokes)`, and `Entropic Resistance`. 
- Created `chinese-humanities.md` containing `Anyang`, `Erlitou`, `Haojing`, `Luoyang`, and `Xianyang`, and created `fluid-mechanics-environmental-hydrodynamics.md` containing `Stage` and `Backwater Zone`.

### Testing
- Verified presence of the requested terms with `rg -n` across the modified and new files, which returned matches for all added items. 
- Confirmed the changes were staged and committed with message `Add requested terminology and new topic files` and that `git status --short` shows a clean working tree. 
- The commit completed successfully and the repository now contains the two new files and the three modified files listed above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5faf40408326b6e4e4d77a715123)